### PR TITLE
Added Environment ConfigurationBuilder

### DIFF
--- a/eShopModernizedWinForms/eShopWCFService/Models/Infrastructure/CatalogConfiguration.cs
+++ b/eShopModernizedWinForms/eShopWCFService/Models/Infrastructure/CatalogConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Web;
 
@@ -13,7 +14,8 @@ namespace eShopWCFService.Models.Infrastructure
         {
             get
             {
-                var envConnectionString = Environment.GetEnvironmentVariable("ConnectionString");
+								//var envConnectionString = Environment.GetEnvironmentVariable("ConnectionString");
+								var envConnectionString = ConfigurationManager.ConnectionStrings["ConnectionString"].ConnectionString;
                 return envConnectionString ?? $"name={configConnectionName}";
             }
         }

--- a/eShopModernizedWinForms/eShopWCFService/Web.config
+++ b/eShopModernizedWinForms/eShopWCFService/Web.config
@@ -2,11 +2,25 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework"
+      type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+      requirePermission="false"/>
+    <section name="configBuilders"
+      type="System.Configuration.ConfigurationBuildersSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+      restartOnExternalChanges="false" requirePermission="false"/>
   </configSections>
+  <configBuilders>
+    <builders>
+      <add name="Environment"
+        type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment, Version=1.0.0.0, Culture=neutral"/>
+    </builders>
+  </configBuilders>
   <appSettings>
     <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true"/>
   </appSettings>
+	<connectionStrings configBuilders="Environment">
+		<!-- Injected from Environment Variables -->
+	</connectionStrings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -16,7 +30,7 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.6.1"/>
+    <compilation debug="true" targetFramework="4.7.1"/>
     <httpRuntime targetFramework="4.6.1"/>
   </system.web>
   <system.serviceModel>
@@ -60,6 +74,7 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="EntityModel" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=eShopDatabase;Persist Security Info=True;" providerName="System.Data.SqlClient"/>
+    <add name="EntityModel" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=eShopDatabase;Persist Security Info=True;"
+      providerName="System.Data.SqlClient"/>
   </connectionStrings>
 </configuration>

--- a/eShopModernizedWinForms/eShopWCFService/eShopWCFService.csproj
+++ b/eShopModernizedWinForms/eShopWCFService/eShopWCFService.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WcfService1</RootNamespace>
     <AssemblyName>WcfService1</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseIISExpress>true</UseIISExpress>
@@ -47,6 +47,12 @@
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Configuration.ConfigurationBuilders.Base, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Configuration.ConfigurationBuilders.Base.1.0.0-preview\lib\Net471\Microsoft.Configuration.ConfigurationBuilders.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Configuration.ConfigurationBuilders.Environment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Configuration.ConfigurationBuilders.Environment.1.0.0-preview\lib\Net471\Microsoft.Configuration.ConfigurationBuilders.Environment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/eShopModernizedWinForms/eShopWCFService/packages.config
+++ b/eShopModernizedWinForms/eShopWCFService/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
+  <package id="Microsoft.Configuration.ConfigurationBuilders.Base" version="1.0.0-preview" targetFramework="net471" />
+  <package id="Microsoft.Configuration.ConfigurationBuilders.Environment" version="1.0.0-preview" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
The EnvironmentConfigurationBuilder is a .NET Framework 4.7.1 feature that allows environment variables to be loaded into the standard ConfigurationManager object.  With this PR, you should be able to avoid accessing the Environment object directly, and let this provider update the configuration as necessary